### PR TITLE
Change concat to merge for lexical task

### DIFF
--- a/zerospeech2021/lexical.py
+++ b/zerospeech2021/lexical.py
@@ -140,10 +140,10 @@ def load_data(gold_file, submission_file):
 
     # merge the gold and score using filenames, then remove the columns
     # 'phones' and 'filename' as we don't use them for evaluation
-    data = pandas.concat([gold, score], axis=1)
+    data = pandas.merge(gold, score, on='filename', how='inner') 
     data.reset_index(inplace=True)
     data.drop(columns=['phones', 'filename'], inplace=True)
-
+    
     # going from a word per line to a pair (word, non word) per line
     data = pandas.concat([
         data.loc[data['correct'] == 1].reset_index().rename(


### PR DESCRIPTION
In the current version, on the current sWUGGY test set:

```
number of lines in gold: 80000
numbers of lines in score: 80000
number of lines in merge(gold,score): 80000
```

Gold (containing 1 file per line) has the same length than score (containing 1 pseudo-probability per line).
However, when these lengths are different (when a file appears in multiple trials for instance), the code breaks and returns the following error.

```
pandas.errors.InvalidIndexError: Reindexing only valid with uniquely valued Index objects
```

This PR fixes this issue so that 1 file can appear in multiple trials (for example: "chuse" being the non-word of "chose" and "chaise"). This way, on Hadrien's sWUGGY (FR testset_64), we have something like:

```
number of lines in gold: 25952
numbers of lines in score: 25416
number of lines in merge(gold,score): 25952
```

For info, here's an example of duplicate lines that appear in this configuration: 

```
id,filename,voice,frequency,word,phones,length,correct
d_ɑ̃_d_ɑ̃-fr-FR-Wavenet-A   192  fr-FR-Wavenet-A       <NA>  NaN  d ɑ̃ d ɑ̃       4      0.0 -119.556732
d_ɑ̃_d_ɑ̃-fr-FR-Wavenet-A  1368  fr-FR-Wavenet-A       <NA>  NaN  d ɑ̃ d ɑ̃       4      0.0 -119.556732
```

`d ɑ̃ d ɑ̃` does appear in trials 192, and 1368, which wasn't possible before :)
